### PR TITLE
Fix reauth URL not working

### DIFF
--- a/src/shopify-auth/exceptions.ts
+++ b/src/shopify-auth/exceptions.ts
@@ -59,7 +59,7 @@ export class ShopifyAuthExceptionFilter implements ExceptionFilter {
         .json({
           statusCode: status,
           timestamp: new Date().toISOString(),
-          message: exception.initMessage(),
+          message: exception.message,
         });
     } else if (exception instanceof ReauthRedirectException) {
       const basePath = this.offlineOptions?.basePath || '';

--- a/src/shopify-auth/module.ts
+++ b/src/shopify-auth/module.ts
@@ -7,6 +7,7 @@ import {
   ShopifyOnlineAuthController,
   ShopifyOfflineAuthController,
 } from './controllers';
+import { getShopifyAuthProviderToken } from './constants';
 
 @Module({})
 export class ShopifyAuthModule implements OnModuleInit {
@@ -15,12 +16,14 @@ export class ShopifyAuthModule implements OnModuleInit {
   ): Promise<DynamicModule> | DynamicModule {
     return {
       module: ShopifyAuthModule,
+      global: true,
       imports: options.imports || [],
       providers: [
         ...(options.providers || []),
         ...createShopifyAuthAsyncOptionsProviders(options, AccessMode.Online),
       ],
       controllers: [ShopifyOnlineAuthController, ShopifyGraphQLController],
+      exports: [getShopifyAuthProviderToken(AccessMode.Online)],
     };
   }
 
@@ -29,12 +32,14 @@ export class ShopifyAuthModule implements OnModuleInit {
   ): Promise<DynamicModule> | DynamicModule {
     return {
       module: ShopifyAuthModule,
+      global: true,
       imports: options.imports || [],
       providers: [
         ...(options.providers || []),
         ...createShopifyAuthAsyncOptionsProviders(options, AccessMode.Offline),
       ],
       controllers: [ShopifyOfflineAuthController],
+      exports: [getShopifyAuthProviderToken(AccessMode.Offline)],
     };
   }
 


### PR DESCRIPTION
The offlline/online auth options were undefined, because the tokens could not be found. Making the module Global and re-exporting the option tokens fixes it.